### PR TITLE
Remove Obsolete Cloneclean Cron Jobs on 'ptsupdate'

### DIFF
--- a/menu/roles/remove/tasks/main.yml
+++ b/menu/roles/remove/tasks/main.yml
@@ -45,3 +45,30 @@
     name: Hourly downloads cleaner
     state: absent
   ignore_errors: yes
+  
+- name: Get running processes list from remote host
+  ignore_errors: yes
+  shell: "ps -few | grep cloneclean | awk '{print $2}'"
+  register: running_processes
+  
+- name: Kill running processes
+  ignore_errors: yes
+  shell: "kill {{ item }}"
+  with_items: "{{ running_processes.stdout_lines }}"
+  
+- wait_for:
+    path: "/proc/{{ item }}/status"
+    state: absent
+  with_items: "{{ running_processes.stdout_lines }}"
+  ignore_errors: yes
+  register: cloneclean_processes
+ 
+- name: Force kill stuck processes
+  ignore_errors: yes
+  shell: "kill -9 {{ item }}"
+  with_items: "{{ cloneclean_processes.results | select('failed') | map(attribute='item') | list }}"
+  
+- service:
+    name: cloneclean
+    state: restarted
+

--- a/menu/roles/remove/tasks/main.yml
+++ b/menu/roles/remove/tasks/main.yml
@@ -34,3 +34,14 @@
   shell: 'apt-get purge snap -yqq 1>/dev/null 2>&1'
   ignore_errors: yes
 
+- name: Remove old Clone Clean Cron Job
+  cron:
+    name: Hourly Clean Clone Clean
+    state: absent
+  ignore_errors: yes
+
+- name: Remove old Downloads Cleaner Cron Job
+  cron:
+    name: Hourly downloads cleaner
+    state: absent
+  ignore_errors: yes


### PR DESCRIPTION
Possibly duplicating Cloneclean script every time the Cron is run. Cloneclean is now set up as a service which works but old installs still have Cron Job running. New installs do not have this Cron Job.